### PR TITLE
[FIX]Adapt requirements for debian bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,13 @@ gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
 gevent==20.9.0 ; python_version > '3.7' and python_version <= '3.9'
-gevent==21.8.0 ; python_version > '3.9'  # (Jammy)
+gevent==21.8.0 ; python_version > '3.9' and python_version < '3.11' # (Jammy)
+gevent==22.8.0 ; python_version >= '3.11'  # (Bookworm)
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version == '3.7'
 greenlet==0.4.17 ; python_version > '3.7' and python_version <= '3.9'
-greenlet==1.1.2 ; python_version  > '3.9'  # (Jammy)
+greenlet==1.1.2 ; python_version  > '3.9'  and python_version < '3.11' # (Jammy)
+greenlet==1.1.3 ; python_version  >= '3.11'  #(Bookworm)
 idna==2.6
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
@@ -33,7 +35,8 @@ ofxparse==0.21; python_version > '3.9'  # (Jammy) ABC removed from collections i
 passlib==1.7.1
 Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
-Pillow==8.1.1 ; python_version > '3.7'
+Pillow==8.1.1 ; python_version > '3.7' and python_version < '3.11'
+Pillow==9.0.0 ; python_version >= '3.11' # (Bookworm)
 polib==1.1.0
 psutil==5.6.6
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
@@ -47,7 +50,8 @@ pytz  # no version pinning to avoid OS perturbations
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.13; python_version < '3.8'
-reportlab==3.5.55; python_version >= '3.8'
+reportlab==3.5.55; python_version >= '3.8' and python_version < '3.11' 
+reportlab==3.6.12; python_version >= '3.11' # (Bookworm)
 requests==2.21.0; python_version <= '3.9'
 requests==2.25.1; python_version > '3.9'  # (Jammy) versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 urllib3==1.26.5; python_version > '3.9'  # (Jammy) indirect / min version = 1.25.8 (Focal with security backports)


### PR DESCRIPTION
Bookworm come with python3.11 by default.
Multiple issues while installing requirements : 
* https://github.com/gevent/gevent/issues/1903
* https://bugzilla.redhat.com/show_bug.cgi?id=2034174 

This PR proposed to use proper lib versions

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
